### PR TITLE
Update Build-Deploy Script and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-1107 AS base
+FROM registry.access.redhat.com/ubi8/ubi-minimal AS base
 
 ARG OPENRESTY_RPM_VERSION="1.19.3"
 

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -4,6 +4,7 @@ set -exv
 
 IMAGE="quay.io/cloudservices/insights-3scale"
 IMAGE_TAG=apicast-base-$(git rev-parse --short=7 HEAD)
+SECURITY_COMPLIANCE_TAG="apicast-base-sc-$(date +%Y%m%d)"
 
 if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
     echo "QUAY_USER and QUAY_TOKEN must be set"
@@ -17,6 +18,6 @@ docker --config="$DOCKER_CONF" build --no-cache -t "${IMAGE}:${IMAGE_TAG}" .
 docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
 
 if [[ $GIT_BRANCH == *"security-compliance"* ]]; then
-    docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:apicast-base-security-compliance"
-    docker --config="$DOCKER_CONF" push "${IMAGE}:apicast-base-security-compliance"
+    docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:apicast-base-${SECURITY_COMPLIANCE_TAG}"
+    docker --config="$DOCKER_CONF" push "${IMAGE}:apicast-base-${SECURITY_COMPLIANCE_TAG}"
 fi


### PR DESCRIPTION
## Description of Intent of Change(s)
This PR is to update the `build_deploy.sh` script with the `SECURITY_COMPLIANCE_TAG` variable. 

This variable aids in the automated weekly builds based on the `security-compliance` branch to be tagged in the following manner, sc-YYYYMMDD. 

- _(e.g., sc-20230501)_

Additionally, the use of `ubi8-minimal` base image has been untagged in the Dockerfile to ensure the newest version is always pulled when rebuilding the `security-compliance` version of the `apicast-base` image.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist
