### PR TITLE
Updating Build_Deploy Script and Adding PlatSec GH Workflow

### DIFF
--- a/.github/workflows/platfrom-security-workflow.yml
+++ b/.github/workflows/platfrom-security-workflow.yml
@@ -1,0 +1,44 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# The default values used in the docker build commands are the root
+# directory '.' and the dockerfile name of 'Dockerfile'. If there is 
+# a need to change these do so in your local workflow template (this file) and
+# change them there. HINT: Look at the bottom of this file.
+
+# This workflow checks out code, builds an image, performs a container image
+# vulnerability scan with Anchore's Grype tool, and generates an
+# SBOM via Anchore's Syft tool
+
+# For more information on Anchore's container image scanning tool Grype, see
+# https://github.com/anchore/grype
+
+# For more information about the Anchore SBOM tool, Syft, see
+# https://github.com/anchore/syft
+
+name: ConsoleDot Platform Security Scan
+
+on:
+  push:
+    branches: [ "main", "master", "security-compliance" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main", "master", "security-compliance" ]
+
+jobs:
+  PlatSec-Security-Workflow:
+    uses: RedHatInsights/platform-security-gh-workflow/.github/workflows/platsec-security-scan-reusable-workflow.yml@master
+    ## The optional parameters below are used if you are using something other than the
+    ## the defaults of root '.' for the path and 'Dockerfile' for the Dockerfile name.
+    ## Additionally, if you have a Dockerfile you use as your BASE_IMG or you need to
+    ## use '--build-arg', those can be define below as well.
+
+    # with:
+    #   dockerfile_path: './test'
+    #   dockerfile_name: 'Dockerfile.main'
+    #   base_image_build: true
+    #   base_dockerfile_path: './test'
+    #   base_dockerfile_name: 'Dockerfile.base'
+    #   build_arg: '--build-arg BASE_IMAGE="localbuild/baseimage:latest"'

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -2,8 +2,10 @@
 
 set -exv
 
-IMAGE="quay.io/cloudservices/insights-3scale"
-IMAGE_TAG=apicast-base-$(git rev-parse --short=7 HEAD)
+IMAGE="quay.io/cloudservices/apicast-base"
+IMAGE_TAG=$(git rev-parse --short=7 HEAD)
+LATEST_TAG="latest"
+SECURITY_COMPLIANCE_TAG="sc-$(date +%Y%m%d)"
 
 if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
     echo "QUAY_USER and QUAY_TOKEN must be set"
@@ -17,6 +19,9 @@ docker --config="$DOCKER_CONF" build --no-cache -t "${IMAGE}:${IMAGE_TAG}" .
 docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
 
 if [[ $GIT_BRANCH == *"security-compliance"* ]]; then
-    docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:apicast-base-security-compliance"
-    docker --config="$DOCKER_CONF" push "${IMAGE}:apicast-base-security-compliance"
+    docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:${SECURITY_COMPLIANCE_TAG}"
+    docker --config="$DOCKER_CONF" push "${IMAGE}:${SECURITY_COMPLIANCE_TAG}"
+else
+    docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:${LATEST_TAG}"
+    docker --config="$DOCKER_CONF" push "${IMAGE}:${LATEST_TAG}"
 fi


### PR DESCRIPTION
### Overview:
- Updated the `build_deploy.sh` file to now push images to the dedicated `https://quay.io/repository/cloudservices/apicast-base` Quay Repo. 

- The `build_deploy.sh` will now generate an image with the `latest` tag.

- The [PlatSec GH Workflow](https://github.com/RedHatInsights/platform-security-gh-workflow) has been added to this GH repo. 