### PR TITLE
[RHCLOUD-32031] use temp directory for docker config

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -13,7 +13,19 @@ if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
     exit 1
 fi
 
-DOCKER_CONF="$PWD/.docker"
+# Create tmp dir to store data in during job run (do NOT store in $WORKSPACE)
+export TMP_JOB_DIR=$(mktemp -d -p "$HOME" -t "jenkins-${JOB_NAME}-${BUILD_NUMBER}-XXXXXX")
+echo "job tmp dir location: $TMP_JOB_DIR"
+
+function job_cleanup() {
+    echo "cleaning up tmp job dir: $TMP_JOB_DIR"
+    rm -fr $TMP_JOB_DIR
+}
+
+trap job_cleanup EXIT ERR SIGINT SIGTERM
+
+DOCKER_CONF="$TMP_JOB_DIR/.docker"
+
 mkdir -p "$DOCKER_CONF"
 docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 docker --config="$DOCKER_CONF" build --no-cache -t "${IMAGE}:${IMAGE_TAG}" .


### PR DESCRIPTION
[RHCLOUD-32031](https://issues.redhat.com/browse/RHCLOUD-32031)

according step 1 in [Credential Leak Self Assessment document ](https://docs.google.com/document/d/1IsX7NmMnWPcuOseyjjUj_T9VjBXx7p3UjWs5eNpDHyI/edit?tab=t.0) use temp directory for docker config