### PR TITLE
add renovate config file and disable dependency updates for security-compliance branch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "matchBaseBranches": ["security-compliance"],
+      "enabled": false,
+      "prCreation": "off"
+    }
+  ]
+}


### PR DESCRIPTION
renovate docs: https://docs.renovatebot.com/configuration-options/#matchbasebranches

internal konflux docs: https://konflux.pages.redhat.com/docs/users/mintmaker/user.html#available-managers

we need to disable creation of konflux-bot PRs for `security-compliance `branch