### PR TITLE
update 'task-git-clone-oci-ta' ref to the latest version

### DIFF
--- a/.tekton/apicast-base-pull-request.yaml
+++ b/.tekton/apicast-base-pull-request.yaml
@@ -178,7 +178,7 @@ spec:
         - name: name
           value: git-clone-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta@sha256:0f4360ce144d46171ebd2e8f4d4575539a0600e02208ba5fc9beeb2c27ddfd4c
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:d35e5d501cb5f5f88369511f76249857cb5ac30250e1dcf086939321964ff6b9
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
`enterprise-contract `pipeline is failing because of 

```
✕ [Violation] tasks.required_untrusted_task_found
  ImageRef: quay.io/redhat-user-workloads/hcc-accessmanagement-tenant/rbac/insights-rbac@sha256:b823379e49160abf1a9fbd3ddb14c61c8fbbb30524e50da8fe920f12ff665069
  Reason: Required task "git-clone-oci-ta" is required and present but not from a trusted task
  Term: git-clone-oci-ta
  Title: All required tasks are from trusted tasks
  Description: Ensure that the all required tasks are resolved from trusted tasks. To exclude this rule add
  "tasks.required_untrusted_task_found:git-clone-oci-ta" to the `exclude` section of the policy configuration.
  Solution: Make sure all required tasks in the build pipeline are resolved from trusted tasks.
```