### PR TITLE
UBI9 Migration Update

### DIFF
--- a/Dockerfile.devel
+++ b/Dockerfile.devel
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8:8.10-1754489414
+FROM registry.access.redhat.com/ubi9/ubi:9.6
 
 ARG OPENRESTY_RPM_VERSION="1.21.4-1.el8"
 ARG LUAROCKS_VERSION="2.3.0"
@@ -9,15 +9,15 @@ WORKDIR /tmp
 ENV APP_ROOT=/opt/app-root \
     HOME=/opt/app-root/src \
     PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
-    PLATFORM="el8"
+    PLATFORM="el9"
 
 RUN sed -i s/enabled=./enabled=0/g /etc/yum/pluginconf.d/subscription-manager.conf
 
-RUN yum upgrade -y
+RUN yum upgrade -y --assumeyes --quiet
 
 RUN dnf install -y 'dnf-command(config-manager)'
 
-RUN yum install -y \
+RUN yum install -y --allowerasing \
         gcc make git which curl iputils bind-utils expat-devel kernel-headers openssl-devel m4 \
         libyaml libyaml-devel perl-local-lib perl-App-cpanminus
 


### PR DESCRIPTION
## Overview

This PR updates the APIcast Docker images from UBI8 to UBI9 base images:

### Key Changes

  - Base Image Update: Migrated from registry.access.redhat.com/ubi8/ubi-minimal to registry.access.redhat.com/ubi9/ubi-minimal
  - **Platform Configuration:** Updated `PLATFORM` environment variable from `el8` to `el9`
  - **Package Manager Modernization:**
    - Replaced `microdnf` with `dnf` for package installation
    - Added `--allowerasing` and `--setopt=tsflags=nodocs` flags for more efficient package management
    - Improved package installation with better formatting and explicit flags
  - **Cleanup Optimization:** Enhanced package cleanup process with `dnf autoremove` and improved cache clearing

### Files Modified

  - `Dockerfile` - Production runtime image updated to `UBI9`
  - `Dockerfile.devel` - Development image updated to `UBI9` with improved package management

### Benefits

  - Aligns with Red Hat's current UBI9 platform
  - Better security posture with latest `UBI9` base image
  - Maintains compatibility with existing OpenResty and dependency versions
