### PR TITLE
Fix runtime library and increase client body buffer size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/hi/core-runtime:2.42-openssl-fips-builder AS bas
 
 USER root
 
-ARG OPENRESTY_RPM_VERSION="1.29.2.5-1.el9"
+ARG OPENRESTY_RPM_VERSION="1.27.1-1.el9"
 ARG LUAROCKS_VERSION="3.12.0"
 
 LABEL summary="The 3scale API gateway (APIcast) is an OpenResty application, which consists of two parts: NGINX configuration and Lua files." \

--- a/Dockerfile
+++ b/Dockerfile
@@ -119,7 +119,8 @@ WORKDIR /opt/app-root/app
 COPY --from=base /usr/bin/sed /usr/bin/sed
 COPY --from=base /usr/bin/perl /usr/bin/perl
 COPY --from=base /usr/share/perl5 /usr/share/perl5
-COPY --from=base /usr/lib64 /usr/lib64
+COPY --from=base /usr/lib64/lua /usr/lib64/lua
+COPY --from=base /usr/lib64/libcrypt.so.2* /usr/lib64/
 
 USER 1001
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/hi/core-runtime:2.42-openssl-fips-builder AS bas
 
 USER root
 
-ARG OPENRESTY_RPM_VERSION="1.27.1-1.el9"
+ARG OPENRESTY_RPM_VERSION="1.29.2.5-1.el9"
 ARG LUAROCKS_VERSION="3.12.0"
 
 LABEL summary="The 3scale API gateway (APIcast) is an OpenResty application, which consists of two parts: NGINX configuration and Lua files." \

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,6 +127,7 @@ USER 1001
 ENV LUA_CPATH "./?.so;/usr/lib64/lua/5.1/?.so;/usr/lib64/lua/5.1/loadall.so;/usr/local/lib64/lua/5.1/?.so"
 ENV LUA_PATH "/usr/lib64/lua/5.1/?.lua;/usr/local/share/lua/5.1/?.lua;/usr/local/share/lua/5.1/*/?.lua;;"
 ENV PATH="/opt/app-root/bin:/opt/app-root/src/bin:/usr/local/openresty/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/app-root/lib"
 
 WORKDIR /opt/app-root
 ENTRYPOINT ["container-entrypoint"]

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -2,7 +2,7 @@
 
 APIcast v2 has a number of parameters configured as [environment variables](#environment-variables) that can modify the behavior of the gateway. The following reference provides descriptions of these parameters.
 
-Note that when deploying APIcast v2 with OpenShift, some of these parameters can be configured via OpenShift template parameters. The latter can be consulted directly in the [template](https://raw.githubusercontent.com/3scale/apicast/master/openshift/apicast-template.yml).
+Note that when deploying APIcast v2 with OpenShift, some of these parameters can be configured via OpenShift template parameters. The latter can be consulted directly in the [template](https://github.com/3scale/apicast/blob/master/openshift/apicast-template.yml).
 
 ## Environment variables
 

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -2,7 +2,7 @@
 
 APIcast v2 has a number of parameters configured as [environment variables](#environment-variables) that can modify the behavior of the gateway. The following reference provides descriptions of these parameters.
 
-Note that when deploying APIcast v2 with OpenShift, some of these parameters can be configured via OpenShift template parameters. The latter can be consulted directly in the [template](https://github.com/3scale/apicast/blob/master/openshift/apicast-template.yml).
+Note that when deploying APIcast v2 with OpenShift, some of these parameters can be configured via OpenShift template parameters. The latter can be consulted directly in the template.
 
 ## Environment variables
 

--- a/gateway/http.d/core.conf
+++ b/gateway/http.d/core.conf
@@ -1,3 +1,4 @@
 client_max_body_size 0;
+client_body_buffer_size 1m;
 
 large_client_header_buffers {{env.APICAST_LARGE_CLIENT_HEADER_BUFFERS | default:  "4 8k"}};


### PR DESCRIPTION
Replace blanket COPY of /usr/lib64 from builder to runtime stage with targeted copies of only the required libraries (lua modules and libcrypt). The previous approach overwrote the runtime image's system libraries (OpenSSL, NSS, c-ares, etc.) causing TLS/DNS failures and 502 errors under production load.

Also add client_body_buffer_size 1m to reduce request body buffering warnings for upload endpoints.