### PR TITLE
fix: remove TLSv1.1 from SSL protocol lists

### DIFF
--- a/gateway/http.d/ssl.conf
+++ b/gateway/http.d/ssl.conf
@@ -10,7 +10,7 @@
 # at most 100 intermediate CA certificates and a final trust anchor certificate.
 lua_ssl_verify_depth 100;
 lua_ssl_trusted_certificate "{{ ca_bundle | default: 'ca-bundle.crt' }}";
-lua_ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
+lua_ssl_protocols TLSv1.2 TLSv1.3;
 
 proxy_ssl_server_name on;
 proxy_ssl_name $http_host;
@@ -18,4 +18,4 @@ proxy_ssl_verify_depth 100;
 
 proxy_ssl_trusted_certificate "{{ ca_bundle | default: 'ca-bundle.crt' }}";
 
-proxy_ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
+proxy_ssl_protocols TLSv1.2 TLSv1.3;


### PR DESCRIPTION
## Summary

Removes TLSv1.1 from `lua_ssl_protocols` and `proxy_ssl_protocols` in `gateway/http.d/ssl.conf`.

TLSv1.1 is deprecated per [RFC 8996](https://www.rfc-editor.org/rfc/rfc8996) and should not be offered. TLSv1.2 and TLSv1.3 remain; TLSv1.3 is already present which supports PQC cipher suites (X25519Kyber768).

Note: the listener-side `ssl_protocols` in `gateway/http.d/apicast.conf.liquid` already correctly specifies `TLSv1.2 TLSv1.3` — no change needed there.

## Changes

- `gateway/http.d/ssl.conf`: `lua_ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3` → `TLSv1.2 TLSv1.3`
- `gateway/http.d/ssl.conf`: `proxy_ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3` → `TLSv1.2 TLSv1.3`

## Related

Addresses RHCLOUD-49158 ([PQC] APICast).